### PR TITLE
feat: Make reports collapsible

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ function GithubReporter (runner, options) {
       failedTests: self.failedTests
     }
     var overallContent = getTemplateContent(path.join(__dirname, './templates/overall.template'), opts)
-    config.reportContent = overallContent + config.formatter(self.rootSuite, 0)
+    config.reportContent = "<details><summary>Click for report</summary>" + overallContent + config.formatter(self.rootSuite, 0) + "</details>"
   })
 }
 


### PR DESCRIPTION
I think this is necessary because of the overwhelming number of test cases most projects have, which makes looking at a PR cumbersome. For example: At our organization we use this reporter and due to a large number of tests, I end up having to scroll a lot.

I have added a quick fix for now, please suggest if there is a better way to do it.
